### PR TITLE
force task exit code of 0

### DIFF
--- a/src/aimes/skeleton/task.c
+++ b/src/aimes/skeleton/task.c
@@ -251,7 +251,7 @@ void compute_flop(double task_length)
     printf("floating point operations : %f\n", task_length);
 
     // Simple fibonacci generation
-    for ( i = 0; i < int(task_length) ; i++ ){
+    for ( i = 0; i < task_length ; i++ ){
         c = a+b;
         a = b;
         b = c;
@@ -759,5 +759,7 @@ int main(int argc, char **argv)
     free(input_names);
     free(output_names);
     free(output_sizes);
+
+    exit(0);
 }
 


### PR DESCRIPTION
This patch really just adds an `exit(0)` to `task` to force a clean exit code.  It also removes a cast over which my gcc stumbles -- AFAICS it is not necessary to cast at that point anyway.